### PR TITLE
fix for Erlang 19 and change to hackney as http client

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,8 @@
 {deps,
  [{mochiweb, "",
    {git, "https://github.com/mochi/mochiweb.git",
-    {branch, "master"}}}]}.
+    {branch, "master"}}},
+  {hackney, ".*", {git, "git://github.com/benoitc/hackney.git", {branch, "master"}}}]}.
 
 {require_otp_vsn, "R16|17|18"}.
 {erl_opts,
@@ -25,4 +26,3 @@
   warn_unused_function,
   warn_unused_record,
   warn_unused_vars]}.
-

--- a/src/twilio.app.src
+++ b/src/twilio.app.src
@@ -8,7 +8,7 @@
   {env, []},
   {applications, [
     mochiweb,
-    inets,
+    hackney,
     crypto,
     stdlib,
     kernel]},

--- a/src/twilio_twiml_ext_recipies.erl
+++ b/src/twilio_twiml_ext_recipies.erl
@@ -20,7 +20,7 @@
         ]).
 
 random() ->
-    N = random:uniform(15),
+    N = rand:uniform(15),
     recipe(N).
 
 recipe(N) ->


### PR DESCRIPTION
Had weird issues with talking to the twilio API. First request works, any subsequent gives '400 Bad Request'. After a while a timeout occurs:
```
2016-12-08 15:31:33.454 [warning] <0.2131.0> Received unexpected ssl data on {sslsocket,{gen_tcp,#Port<0.144263>,tls_connection,undefined},<0.2132.0>}
   Data:       <<"HTTP/1.1 408 REQUEST_TIMEOUT\r\nContent-Length:0\r\nConnection: Close\r\n\r\n">>
   MFA:        undefined
   Request:    undefined
   Session:    {session,{{"api.twilio.com",443},<0.2131.0>},false,https,{sslsocket,{gen_tcp,#Port<0.144263>,tls_connection,undefined},<0.2132.0>},{essl,[]},1,keep_alive,true}
   Status:     keep_alive
   StatusLine: undefined
   Profile:    httpc_manager
```
As a consequence no requests can be made at all, the call just blocks.

I'm in a project using cowboy which also uses inets. Maybe that's why?

Going to hackney solved the problem for me. ¯\_(ツ)_/¯ 
